### PR TITLE
Support Aliasing

### DIFF
--- a/src/data-api-driver.ts
+++ b/src/data-api-driver.ts
@@ -107,7 +107,7 @@ class DataApiConnection implements DatabaseConnection {
         (rec) =>
           Object.fromEntries(
             rec.map((val, i) => [
-              r.columnMetadata![i].label ? r.columnMetadata![i].label : r.columnMetadata![i].name,
+              r.columnMetadata![i].label || r.columnMetadata![i].name,
               val.stringValue ??
                 val.blobValue ??
                 val.longValue ??

--- a/src/data-api-driver.ts
+++ b/src/data-api-driver.ts
@@ -107,7 +107,7 @@ class DataApiConnection implements DatabaseConnection {
         (rec) =>
           Object.fromEntries(
             rec.map((val, i) => [
-              r.columnMetadata![i].name,
+              r.columnMetadata![i].label ? r.columnMetadata![i].label : r.columnMetadata![i].name,
               val.stringValue ??
                 val.blobValue ??
                 val.longValue ??

--- a/test/temporary.test.ts
+++ b/test/temporary.test.ts
@@ -16,6 +16,11 @@ const PERSON = {
   last_name: "bezos",
 } as const;
 
+const PERSON_ALIAS = {
+    first: "jeff",
+    last: "bezos"
+}
+
 it("insert and read", async () => {
   await db
     .insertInto("person")
@@ -28,6 +33,12 @@ it("insert and read", async () => {
   const result = await db.selectFrom("person").selectAll().execute();
   expect(result).toHaveLength(1);
   expect(result[0]).toMatchObject(PERSON);
+});
+
+it("alias return", async () => {
+    const result = await db.selectFrom("person").select(["first_name as first", "last_name as last"]).execute();
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject(PERSON_ALIAS);
 });
 
 it("join", async () => {


### PR DESCRIPTION
currently, aliased columns are not returned by the data-api
the returned column metadata reveals that aliased columns are stored in the ```label``` attribute
if no alias is provided, the ```label``` attribute matches the ```name``` attribute for aurora mysql queries

added logic to check for ```label``` metadata and use this field on returned column, if no ```label``` attribute is found, fall back to ```name``` attribute

