### PR TITLE
Include MySql-only generated insertId in driver response

### DIFF
--- a/src/data-api-driver.ts
+++ b/src/data-api-driver.ts
@@ -98,6 +98,7 @@ class DataApiConnection implements DatabaseConnection {
     if (!r.columnMetadata) {
       return {
         numUpdatedOrDeletedRows: BigInt(r.numberOfRecordsUpdated || 0),
+        insertId: generatedFields && generatedFields.length > 0 ? generatedFields[0].longValue : undefined
         rows: [],
       };
     }


### PR DESCRIPTION
Relates to [Issue 12](https://github.com/serverless-stack/kysely-data-api/issues/12)
Return `insertId` for MySql queries when one is available inside an executed statement response