### PR TITLE
Include MySql-only generated insertId in response

### DIFF
--- a/src/data-api-driver.ts
+++ b/src/data-api-driver.ts
@@ -104,6 +104,7 @@ class DataApiConnection implements DatabaseConnection {
     if (!r.columnMetadata) {
       return {
         numUpdatedOrDeletedRows: BigInt(r.numberOfRecordsUpdated || 0),
+        insertId: r.generatedFields && r.generatedFields.length > 0 ? r.generatedFields[0].longValue : undefined
         rows: [],
       };
     }


### PR DESCRIPTION
Amends the broken PR, that did not include reference to executeStatement result when verifying if insertId value is available