### PR TITLE
add `numAffectedRows` @ `DataApiConnection.executeQuery`.

### DIFF
--- a/src/data-api-driver.ts
+++ b/src/data-api-driver.ts
@@ -102,8 +102,14 @@ class DataApiConnection implements DatabaseConnection {
       })
       .promise();
     if (!r.columnMetadata) {
+      const numAffectedRows = BigInt(r.numberOfRecordsUpdated || 0)
+
       return {
-        numUpdatedOrDeletedRows: BigInt(r.numberOfRecordsUpdated || 0),
+        // @ts-ignore replaces `QueryResult.numUpdatedOrDeletedRows` in kysely > 0.22 
+        // following https://github.com/koskimas/kysely/pull/188
+        numAffectedRows,
+        // deprecated in kysely > 0.22, keep for backward compatibility.
+        numUpdatedOrDeletedRows: numAffectedRows,
         rows: [],
       };
     }


### PR DESCRIPTION
aligns with koskimas/kysely#188 (not released yet)

`QueryResult.numUpdatedOrDeletedRows` is being deprecated in next `kysely` release, and will be removed in the future. It is being replaced with `QueryResult.numAffectedRows` for reasons discussed in linked pull request.